### PR TITLE
Add UI run color selection with persistence

### DIFF
--- a/tests/test_sqlite_storage.py
+++ b/tests/test_sqlite_storage.py
@@ -10,6 +10,7 @@ def test_init_creates_metrics_table(temp_db):
     with sqlite3.connect(db_path) as conn:
         cursor = conn.cursor()
         cursor.execute("SELECT * FROM metrics")
+        cursor.execute("SELECT * FROM runs")
 
 
 def test_log_and_get_metrics(temp_db):
@@ -29,3 +30,10 @@ def test_get_projects_and_runs(temp_db):
     assert {"proj1", "proj2"}.issubset(projects)
     runs = set(SQLiteStorage.get_runs("proj1"))
     assert "run1" in runs
+
+
+def test_set_and_get_run_color(temp_db):
+    SQLiteStorage.log(project="proj1", run="run1", metrics={"a": 1})
+    SQLiteStorage.set_run_color("proj1", "run1", "#FFFFFF")
+    color = SQLiteStorage.get_run_color("proj1", "run1")
+    assert color == "#FFFFFF"

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -25,7 +25,10 @@ def deploy_as_space(
     ):  # in case a repo with this function is uploaded to spaces
         return
 
-    trackio_path = files("trackio")
+    try:
+        trackio_path = files("trackio")
+    except ModuleNotFoundError:
+        trackio_path = Path(__file__).parent
 
     hf_api = huggingface_hub.HfApi()
 

--- a/trackio/ui.py
+++ b/trackio/ui.py
@@ -11,20 +11,20 @@ HfApi = hf.HfApi()
 try:
     from trackio.sqlite_storage import SQLiteStorage
     from trackio.utils import (
+        COLOR_PALETTE,
         RESERVED_KEYS,
         TRACKIO_LOGO_PATH,
         downsample,
         get_color_mapping,
-        COLOR_PALETTE,
     )
 except:  # noqa: E722
     from sqlite_storage import SQLiteStorage
     from utils import (
+        COLOR_PALETTE,
         RESERVED_KEYS,
         TRACKIO_LOGO_PATH,
         downsample,
         get_color_mapping,
-        COLOR_PALETTE,
     )
 
 css = """

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -301,7 +301,10 @@ COLOR_PALETTE = [
 
 def get_color_mapping(project: str, runs: list[str], smoothing: bool) -> dict[str, str]:
     """Generate color mapping for runs with persistence in the database."""
-    from trackio.sqlite_storage import SQLiteStorage
+    try:
+        from trackio.sqlite_storage import SQLiteStorage
+    except:
+        from sqlite_storage import SQLiteStorage
 
     color_map = {}
 

--- a/trackio/utils.py
+++ b/trackio/utils.py
@@ -296,17 +296,22 @@ COLOR_PALETTE = [
     "#EC4899",
     "#06B6D4",
     "#84CC16",
-    "#F97316",
-    "#6366F1",
 ]
 
 
-def get_color_mapping(runs: list[str], smoothing: bool) -> dict[str, str]:
-    """Generate color mapping for runs, with transparency for original data when smoothing is enabled."""
+def get_color_mapping(project: str, runs: list[str], smoothing: bool) -> dict[str, str]:
+    """Generate color mapping for runs with persistence in the database."""
+    from trackio.sqlite_storage import SQLiteStorage
+
     color_map = {}
 
     for i, run in enumerate(runs):
-        base_color = COLOR_PALETTE[i % len(COLOR_PALETTE)]
+        stored_color = SQLiteStorage.get_run_color(project, run)
+        if stored_color is None:
+            stored_color = COLOR_PALETTE[i % len(COLOR_PALETTE)]
+            SQLiteStorage.set_run_color(project, run, stored_color)
+
+        base_color = stored_color
 
         if smoothing:
             color_map[f"{run}_smoothed"] = base_color


### PR DESCRIPTION
## Summary
- allow editing of run colors in the dashboard
- store run color in SQLite database
- expose helpers to get/set run color
- reduce color palette to eight colors
- test persistence of run colors

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fac6e4ca88332afa55c20c987a7b7