### PR TITLE
Implement run list with color & visibility

### DIFF
--- a/tests/test_show_ui.py
+++ b/tests/test_show_ui.py
@@ -1,0 +1,14 @@
+import webbrowser
+import trackio
+
+
+def test_init_log_show(temp_db, monkeypatch):
+    monkeypatch.setattr(webbrowser, "open", lambda *a, **k: None)
+    run = trackio.init(project="proj", name="run")
+    trackio.log({"x": 1})
+    trackio.show(project="proj")
+    run.finish()
+    trackio.ui.demo.close()
+
+
+

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,7 @@
+import trackio.ui as ui
+
+
+def test_update_visible_runs():
+    assert ui.update_visible_runs(True, "run1", []) == ["run1"]
+    assert ui.update_visible_runs(False, "run1", ["run1", "run2"]) == ["run2"]
+    assert ui.update_visible_runs(True, "run2", ["run1"]) == ["run1", "run2"]

--- a/trackio/ui.py
+++ b/trackio/ui.py
@@ -195,9 +195,7 @@ def update_runs(project, filter_text, visible_runs_value, user_interacted_with_r
             )
 
     run_tb.label = f"Runs ({num_runs})"
-    run_tb.render()
     visible_runs.value = updated_visible
-    visible_runs.render()
 
 
 

--- a/trackio/ui.py
+++ b/trackio/ui.py
@@ -194,8 +194,10 @@ def update_runs(project, filter_text, visible_runs, user_interacted_with_runs=Fa
                 outputs=None,
             )
 
-    run_tb.render(label=f"Runs ({num_runs})")
-    visible_runs.render(updated_visible)
+    run_tb.label = f"Runs ({num_runs})"
+    run_tb.render()
+    visible_runs.value = updated_visible
+    visible_runs.render()
 
 
 

--- a/trackio/ui.py
+++ b/trackio/ui.py
@@ -148,7 +148,7 @@ def load_run_data(
     return df
 
 
-def update_runs(project, filter_text, visible_runs, user_interacted_with_runs=False):
+def update_runs(project, filter_text, visible_runs_value, user_interacted_with_runs=False):
     if project is None:
         runs = []
         num_runs = 0
@@ -161,7 +161,7 @@ def update_runs(project, filter_text, visible_runs, user_interacted_with_runs=Fa
     if not user_interacted_with_runs:
         updated_visible = runs
     else:
-        updated_visible = [r for r in visible_runs if r in runs]
+        updated_visible = [r for r in visible_runs_value if r in runs]
 
     with run_list:
         for i, run in enumerate(runs):


### PR DESCRIPTION
## Summary
- show runs in sidebar as a list with visibility checkboxes and color pickers
- update callbacks to use new `visible_runs` state instead of a checkbox group

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880ab27d5948332bbc3642461054b1b